### PR TITLE
Script to rename Mac with standard conventions

### DIFF
--- a/mac-rename.sh
+++ b/mac-rename.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Pull the last 6 of the serial number
+
+serial=$(ioreg -rd1 -c IOPlatformExpertDevice | awk -F'"' '/IOPlatformSerialNumber/{print $4}' | tail -c 7)
+
+#Change computer names to "OSX-" + last 7 
+
+/usr/sbin/scutil --set ComputerName "OSX-$serial"
+/usr/sbin/scutil --set LocalHostName "OSX-$serial"
+/usr/sbin/scutil --set HostName "OSX-$serial"


### PR DESCRIPTION
Renames the MacBook with OSX-"last6 of serial #" in case of re-image or replacement.